### PR TITLE
Added Meteoblue to the Weather section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1859,6 +1859,7 @@ API | Description | Auth | HTTPS | CORS |
 | [HG Weather](https://hgbrasil.com/status/weather) | Provides weather forecast data for cities in Brazil | `apiKey` | Yes | Yes |
 | [Hong Kong Obervatory](https://www.hko.gov.hk/en/abouthko/opendata_intro.htm) | Provide weather information, earthquake information, and climate data | No | Yes | Unknown |
 | [MetaWeather](https://www.metaweather.com/api/) | Weather | No | Yes | No |
+| [Meteoblue](https://content.meteoblue.com/en/business-solutions/weather-apis) | Global weather data with 100+ weather variables, 14 days ahead and 4 days of history data. | `apiKey` | Yes | Yes |
 | [Meteorologisk Institutt](https://api.met.no/weatherapi/documentation) | Weather and climate data | `User-Agent` | Yes | Unknown |
 | [Micro Weather](https://m3o.com/weather/api) | Real time weather forecasts and historic data | `apiKey` | Yes | Unknown |
 | [ODWeather](http://api.oceandrivers.com/static/docs.html) | Weather and weather webcams | No | No | Unknown |


### PR DESCRIPTION
Good Afternoon,

I’m writing on behalf of meteoblue AG (https://www.meteoblue.com/). 

I’ve added Meteoblue to the Weather section of the list. Our Weather APIs provide precise weather forecasts and historical data, offering over 100 weather variables with cutting-edge visualizations. The free service offers forecasts up to 14 days ahead and historical data for the past 4 days.

For more information, please visit:
- Meteoblue Business Solutions Weather APIs: https://content.meteoblue.com/en/business-solutions/weather-apis
- Weather APIs Documentation Overview: https://docs.meteoblue.com/en/weather-apis/introduction/overview/

Thank you
